### PR TITLE
Bump AGP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath "com.android.tools.build:gradle:4.1.2"
+		classpath "com.android.tools.build:gradle:4.2.0"
 	}
 }
 


### PR DESCRIPTION
```
...
> Task :app:mergeReleaseResources FAILED
> Task :app:processReleaseManifest

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeReleaseResources'.

> Multiple task action failures occurred:
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
> AAPT2 aapt2-4.1.2-6503028-linux Daemon #0: Unexpected error during compile '/home/vagrant/build/pl.suve.colorful.android/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
> AAPT2 aapt2-4.1.2-6503028-linux Daemon #5: Unexpected error during compile '/home/vagrant/build/pl.suve.colorful.android/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.
```

ref: https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

Fixed (we'll see heh) directly in F-Droid: https://gitlab.com/fdroid/fdroiddata/-/commit/a1c768c66a5ed3cc0cd06cbe1a02d94f603aeef9